### PR TITLE
add methods for keys stored as stringified Buffer

### DIFF
--- a/job-results/reader-writer.test.ts
+++ b/job-results/reader-writer.test.ts
@@ -24,11 +24,10 @@ describe('Encryption Library Tests', async () => {
 
         const zip = await writer.generate()
 
-        const reader = new ResultsReader(zip)
-
         const privateKey = pemToArrayBuffer(readPrivateKey())
+        const reader = new ResultsReader(zip, privateKey, fingerprint)
 
-        const entries = await reader.decryptZip(privateKey, fingerprint)
+        const entries = await reader.decryptZip()
 
         expect(Object.keys(reader.manifest.files)).toHaveLength(1)
         expect(entries).toHaveLength(1)

--- a/job-results/reader-writer.test.ts
+++ b/job-results/reader-writer.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { readPublicKey, readPrivateKey } from '../testing'
+import { fingerprintKeyData, pemToArrayBuffer } from '../util'
+import { ResultsWriter } from './writer'
+import { ResultsReader } from './reader'
+
+describe('Encryption Library Tests', async () => {
+    it('can create a results file and read it', async () => {
+        const publicKey = pemToArrayBuffer(readPublicKey())
+        const fingerprint = await fingerprintKeyData(publicKey)
+        const writer = new ResultsWriter([
+            {
+                publicKey,
+                fingerprint,
+            },
+        ])
+
+        await writer.addFile('test.data', Buffer.from('hello world!', 'utf-8'))
+
+        expect(writer.manifest.files['test.data']).toMatchObject({
+            path: 'test.data',
+            bytes: 12,
+        })
+
+        const zip = await writer.generate()
+
+        const reader = new ResultsReader(zip)
+
+        const privateKey = pemToArrayBuffer(readPrivateKey())
+
+        const entries = await reader.decryptZip(privateKey, fingerprint)
+
+        expect(Object.keys(reader.manifest.files)).toHaveLength(1)
+        expect(entries).toHaveLength(1)
+        expect(entries[0]).toEqual('hello world!')
+    })
+})

--- a/job-results/reader.ts
+++ b/job-results/reader.ts
@@ -9,16 +9,16 @@ export class ResultsReader {
 
     private zipReader: ZipReader<Blob>
     private fingerprint: string
-    private privateKey: CryptoKey
+    private privateKey: Promise<CryptoKey>
 
-    constructor(zipBlob: Blob) {
+    constructor(zipBlob: Blob, privateKey: ArrayBuffer, fingerprint: string) {
         this.zipReader = new ZipReader(new BlobReader(zipBlob))
+        this.fingerprint = fingerprint
+        this.privateKey = privateKeyFromBuffer(privateKey)
     }
 
-    async decryptZip(privateKey: ArrayBuffer, fingerprint: string): Promise<string[]> {
-        this.fingerprint = fingerprint
+    async decryptZip(): Promise<string[]> {
         await this.decode()
-        this.privateKey = await privateKeyFromBuffer(privateKey)
 
         const generator = this.entries()
         const entries = []
@@ -76,7 +76,7 @@ export class ResultsReader {
             {
                 name: 'RSA-OAEP',
             },
-            this.privateKey,
+            await this.privateKey,
             encryptedKey,
         )
 

--- a/job-results/reader.ts
+++ b/job-results/reader.ts
@@ -9,12 +9,12 @@ export class ResultsReader {
 
     private zipReader: ZipReader<Blob>
     private fingerprint: string
-    private privateKey: Promise<CryptoKey>
+    private privateKey: ArrayBuffer
 
     constructor(zipBlob: Blob, privateKey: ArrayBuffer, fingerprint: string) {
         this.zipReader = new ZipReader(new BlobReader(zipBlob))
         this.fingerprint = fingerprint
-        this.privateKey = privateKeyFromBuffer(privateKey)
+        this.privateKey = privateKey
     }
 
     async decryptZip(): Promise<string[]> {
@@ -76,7 +76,7 @@ export class ResultsReader {
             {
                 name: 'RSA-OAEP',
             },
-            await this.privateKey,
+            await privateKeyFromBuffer(this.privateKey),
             encryptedKey,
         )
 

--- a/job-results/reader.ts
+++ b/job-results/reader.ts
@@ -1,6 +1,6 @@
 import { BlobReader, BlobWriter, Entry, TextWriter, ZipReader } from '@zip.js/zip.js'
 import type { ResultsFile, ResultsManifest } from './types'
-import { privateKeyFromString } from '../util'
+import { privateKeyFromBuffer } from '../util'
 
 export class ResultsReader {
     manifest: ResultsManifest = {
@@ -8,14 +8,19 @@ export class ResultsReader {
     }
 
     private zipReader: ZipReader<Blob>
-    fingerprint: string
-    privateKey: CryptoKey
+    private fingerprint: string
+    private privateKey: CryptoKey
 
-    async decryptZip(zipBlob: Blob, privateKey: string, fingerprint: string): Promise<string[]> {
+    constructor(zipBlob: Blob) {
+        this.zipReader = new ZipReader(new BlobReader(zipBlob))
+    }
+
+    async decryptZip(privateKey: ArrayBuffer, fingerprint: string): Promise<string[]> {
         this.fingerprint = fingerprint
-        await this.decode(zipBlob)
-        await this.parseKeys(privateKey)
-        const generator = await this.entries()
+        await this.decode()
+        this.privateKey = await privateKeyFromBuffer(privateKey)
+
+        const generator = this.entries()
         const entries = []
         for await (const entry of generator) {
             const decodedContents = new TextDecoder().decode(entry.contents)
@@ -24,9 +29,7 @@ export class ResultsReader {
         return entries
     }
 
-    private async decode(zipBlob: Blob) {
-        this.zipReader = new ZipReader(new BlobReader(zipBlob))
-
+    private async decode() {
         const entries = await this.zipReader.getEntries()
         for (const entry of entries) {
             if (entry.getData && entry.filename == 'manifest.json') {
@@ -90,9 +93,5 @@ export class ResultsReader {
             aesKey,
             arrayBuffer,
         )
-    }
-
-    async parseKeys(privateKeyString: string) {
-        this.privateKey = await privateKeyFromString(privateKeyString)
     }
 }

--- a/job-results/types.ts
+++ b/job-results/types.ts
@@ -4,7 +4,7 @@ type ResultsFileKey = string
 
 export type PublicKey = {
     fingerprint: string // sha 256 fingerprint of members public key
-    publicKey: string // PEM encoded RSA public key
+    publicKey: ArrayBuffer
 }
 
 export type FileKeyMap = {

--- a/job-results/writer.ts
+++ b/job-results/writer.ts
@@ -50,10 +50,9 @@ export class ResultsWriter {
 
     private async encryptAesKeyWithPublicKey(key: PublicKey, aesKey: ArrayBuffer): Promise<string> {
         // Decode the public key
-        const publicKeyBuffer = Buffer.from(key.publicKey, 'base64')
         const publicKey = await crypto.subtle.importKey(
             'spki',
-            publicKeyBuffer,
+            key.publicKey,
             {
                 name: 'RSA-OAEP',
                 hash: 'SHA-256',

--- a/util/keypair.test.ts
+++ b/util/keypair.test.ts
@@ -6,6 +6,7 @@ import {
     serializedBufferToPublicKey,
     pemToArrayBuffer,
     SerializedBuffer,
+    pemToJSONBuffer,
 } from './keypair'
 import { readPublicKey } from '../testing'
 
@@ -55,6 +56,14 @@ describe('Encryption Library KeyPair Tests', () => {
         const fingerprint2 = await fingerprintKeyData(publicKeyData2)
 
         expect(fingerprint1).not.toEqual(fingerprint2)
+    })
+
+    it('can generate a data structure from key for testing', async () => {
+        const data = pemToJSONBuffer(readPublicKey())
+        expect(data).toMatchObject({
+            type: 'Buffer',
+            data: expect.any(Array),
+        })
     })
 
     it('can parse a public key from binary data', async () => {

--- a/util/keypair.test.ts
+++ b/util/keypair.test.ts
@@ -2,16 +2,14 @@ import { describe, it, expect } from 'vitest'
 import {
     arrayBufferToHex,
     generateKeyPair,
-    fingerprintFromPublicKey,
-    fingerprintFromPrivateKey,
-    privateKeyFromString,
+    fingerprintKeyData,
     serializedBufferToPublicKey,
     pemToArrayBuffer,
     SerializedBuffer,
 } from './keypair'
 import { readPublicKey } from '../testing'
 
-describe('Encryption Library Tests', () => {
+describe('Encryption Library KeyPair Tests', () => {
     it('should generate a public/private key pair and export keys', async () => {
         const {
             publicKey,
@@ -34,42 +32,35 @@ describe('Encryption Library Tests', () => {
     })
 
     it('should create a fingerprint from the public key string', async () => {
-        const { publicKeyString } = await generateKeyPair()
-        const fingerprint = await fingerprintFromPublicKey(publicKeyString)
+        const { exportedPublicKey } = await generateKeyPair()
+        const fingerprint = await fingerprintKeyData(exportedPublicKey)
 
         expect(fingerprint).toBeTypeOf('string')
         expect(fingerprint.length).toBe(64) // SHA-256 hash is 64 hex characters
     })
 
     it('should create a fingerprint from the private key string', async () => {
-        const { privateKeyString } = await generateKeyPair()
-        const fingerprint = await fingerprintFromPrivateKey(privateKeyString)
+        const { exportedPrivateKey } = await generateKeyPair()
+        const fingerprint = await fingerprintKeyData(exportedPrivateKey)
 
         expect(fingerprint).toBeTypeOf('string')
         expect(fingerprint.length).toBe(64) // SHA-256 hash is 64 hex characters
     })
 
     it('should generate different fingerprints for different key pairs', async () => {
-        const { publicKeyString: publicKeyString1 } = await generateKeyPair()
-        const { publicKeyString: publicKeyString2 } = await generateKeyPair()
+        const { exportedPrivateKey: publicKeyData1 } = await generateKeyPair()
+        const { exportedPrivateKey: publicKeyData2 } = await generateKeyPair()
 
-        const fingerprint1 = await fingerprintFromPublicKey(publicKeyString1)
-        const fingerprint2 = await fingerprintFromPublicKey(publicKeyString2)
+        const fingerprint1 = await fingerprintKeyData(publicKeyData1)
+        const fingerprint2 = await fingerprintKeyData(publicKeyData2)
 
         expect(fingerprint1).not.toEqual(fingerprint2)
     })
 
-    it('should import a private key from a string and create a fingerprint', async () => {
-        const { privateKeyString } = await generateKeyPair()
-        const privateKey = await privateKeyFromString(privateKeyString)
-        const fingerprint = await fingerprintFromPrivateKey(privateKey)
-        expect(fingerprint).toBeTypeOf('string')
-        expect(fingerprint.length).toBe(64) // SHA-256 hash is 64 hex characters
-    })
-
     it('can parse a public key from binary data', async () => {
         const pubKeyStr = readPublicKey()
-        const origFingerprint = await fingerprintFromPublicKey(pubKeyStr)
+        const origFingerprint = await fingerprintKeyData(pemToArrayBuffer(pubKeyStr))
+
         // this is what is produced by JSON.stringify a node Buffer
         const serialized = JSON.parse(JSON.stringify(Buffer.from(pemToArrayBuffer(pubKeyStr)))) as SerializedBuffer
         const publicKey = await serializedBufferToPublicKey(serialized)

--- a/util/keypair.ts
+++ b/util/keypair.ts
@@ -40,6 +40,31 @@ export async function generateKeyPair(): Promise<{
     }
 }
 
+export type SerializedBuffer = {
+    type: string
+    data: number[]
+}
+
+export function serializedBufferToArrayBuffer(input: SerializedBuffer): ArrayBuffer {
+    return new Uint8Array(input.data).buffer
+}
+
+export async function serializedBufferToPublicKey(buffer: SerializedBuffer) {
+    const publicKeyBuffer = serializedBufferToArrayBuffer(buffer)
+
+    const publicKeyImported = await crypto.subtle.importKey(
+        'spki',
+        publicKeyBuffer,
+        {
+            name: 'RSA-OAEP',
+            hash: 'SHA-256',
+        },
+        true,
+        ['encrypt'],
+    )
+    return publicKeyImported
+}
+
 // Helper: Convert a PEM encoded string to an ArrayBuffer.
 export function pemToArrayBuffer(pem: string) {
     // Remove the PEM header, footer, and line breaks.

--- a/util/keypair.ts
+++ b/util/keypair.ts
@@ -26,7 +26,7 @@ export async function generateKeyPair(): Promise<{
     const exportedPrivateKey = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey)
     const privateKeyString = btoa(String.fromCharCode(...new Uint8Array(exportedPrivateKey)))
 
-    const fingerprint = await fingerprintFromPublicKey(publicKeyString)
+    const fingerprint = await fingerprintKeyData(exportedPublicKey)
 
     // TODO Figure out what we want to export
     return {
@@ -91,34 +91,15 @@ export function arrayBufferToHex(buffer: ArrayBuffer) {
         .join('')
 }
 
-export async function fingerprintFromPublicKey(publicKey: string): Promise<string> {
-    const publicKeyBuffer = pemToArrayBuffer(publicKey)
-
-    // Import publicKey
-    const publicKeyImported = await crypto.subtle.importKey(
-        'spki',
-        publicKeyBuffer,
-        {
-            name: 'RSA-OAEP',
-            hash: 'SHA-256',
-        },
-        true,
-        ['encrypt'],
-    )
-
-    // Export the public key as SPKI (DER encoded)
-    const spki = await crypto.subtle.exportKey('spki', publicKeyImported)
-
+export async function fingerprintKeyData(publicKeyBuffer: ArrayBuffer): Promise<string> {
     // Compute the SHA‑256 digest (fingerprint) of the SPKI data
-    const fingerprintBuffer = await crypto.subtle.digest('SHA-256', spki)
+    const fingerprintBuffer = await crypto.subtle.digest('SHA-256', publicKeyBuffer)
 
     // Convert the ArrayBuffer fingerprint into a hexadecimal string (colon-delimited)
     return arrayBufferToHex(fingerprintBuffer)
 }
 
-export async function privateKeyFromString(privateKey: string): Promise<CryptoKey> {
-    const privateKeyBuffer = pemToArrayBuffer(privateKey)
-
+export async function privateKeyFromBuffer(privateKeyBuffer: ArrayBuffer): Promise<CryptoKey> {
     // Import the RSA private key.
     return await crypto.subtle.importKey(
         'pkcs8',
@@ -130,44 +111,4 @@ export async function privateKeyFromString(privateKey: string): Promise<CryptoKe
         true, // Extractable - intended to be used with fingerprintFromPrivateKey
         ['decrypt'],
     )
-}
-
-// TODO Determine whether or not we can just remove this function entirely
-export async function fingerprintFromPrivateKey(privateKey: CryptoKey | string): Promise<string> {
-    if (typeof privateKey === 'string') {
-        privateKey = await privateKeyFromString(privateKey)
-    }
-
-    // Export the private key as JWK to extract the public key parameters (n and e)
-    const jwk = await crypto.subtle.exportKey('jwk', privateKey)
-
-    // Create a JWK object for the public key using modulus (n) and exponent (e)
-    const publicJwk = {
-        kty: jwk.kty,
-        n: jwk.n,
-        e: jwk.e,
-        alg: jwk.alg,
-        ext: true,
-    }
-
-    // Import the public key
-    const publicKey = await crypto.subtle.importKey(
-        'jwk',
-        publicJwk,
-        {
-            name: 'RSA-OAEP', // ensure this matches the private key's algorithm
-            hash: 'SHA-256',
-        },
-        true,
-        ['encrypt'],
-    )
-
-    // Export the public key as SPKI (DER encoded)
-    const spki = await crypto.subtle.exportKey('spki', publicKey)
-
-    // Compute the SHA‑256 digest (fingerprint) of the SPKI data
-    const fingerprintBuffer = await crypto.subtle.digest('SHA-256', spki)
-
-    // Convert the ArrayBuffer fingerprint into a hexadecimal string (colon-delimited)
-    return arrayBufferToHex(fingerprintBuffer)
 }

--- a/util/keypair.ts
+++ b/util/keypair.ts
@@ -41,7 +41,7 @@ export async function generateKeyPair(): Promise<{
 }
 
 export type SerializedBuffer = {
-    type: string
+    type: 'Buffer'
     data: number[]
 }
 
@@ -81,6 +81,12 @@ export function pemToArrayBuffer(pem: string) {
     } else {
         return Buffer.from(b64, 'base64').buffer
     }
+}
+
+// Helper for testing: Convert an PEM key into the format that keys are tranfered as in API requests:
+// { type: 'Buffer', data: [1,2,3,...] }
+export function pemToJSONBuffer(pem: string): SerializedBuffer {
+    return JSON.parse(JSON.stringify(Buffer.from(pemToArrayBuffer(pem))))
 }
 
 // Helper: Convert an ArrayBuffer to a hex string.


### PR DESCRIPTION
The management app will be storing the public key as binary data (implemented in https://github.com/safeinsights/management-app/pull/91) 

because:
* its a bit more efficient both to store and transfer 
* doing so prevents the possibility of confusing it with a string

In api methods the keys are converted to a JSON structure like:
```
"publicKey":{
   "type":"Buffer",
    "data": [48,130,2,34,48,13,6,9,42,134,72,134,247, .... ]
}
```

That's easy to parse because you can `new Uint8Array(publicKey.data)` vs converting to/from hex everywhere.

This adds a few methods and test for this, happy to rework or add other things y'all might find helpful.  There are a lot of other methods in the utils.ts file dealing with PEM encoding, which we maybe could remove, but I didn't want to until we know more about how the lib will be used