### PR TITLE
Update to latest version of zip.js and fix type errors

### DIFF
--- a/job-results/reader.ts
+++ b/job-results/reader.ts
@@ -1,4 +1,5 @@
-import { BlobReader, BlobWriter, Entry, TextWriter, ZipReader } from '@zip.js/zip.js'
+import { BlobReader, BlobWriter, TextWriter, ZipReader } from '@zip.js/zip.js'
+import type { FileEntry as ZipFileEntry } from '@zip.js/zip.js'
 import type { ResultsFile, ResultsManifest, FileEntry } from './types'
 import { privateKeyFromBuffer } from '../util'
 import logger from '../lib/logger'
@@ -40,7 +41,7 @@ export class ResultsReader {
 
         const entries = await this.zipReader.getEntries()
         for (const entry of entries) {
-            if (entry.getData && entry.filename == 'manifest.json') {
+            if (!entry.directory && entry.filename == 'manifest.json') {
                 const manifestText = await entry.getData(new TextWriter())
                 this.manifest = JSON.parse(manifestText) as ResultsManifest
             }
@@ -57,18 +58,14 @@ export class ResultsReader {
         const entries = await this.zipReader.getEntries()
         for (const entry of entries) {
             const file = this.manifest.files[entry.filename]
-            if (entry.getData && file) {
+            if (!entry.directory && file) {
                 const contents = await this.readFile(file, entry)
                 yield { ...file, contents }
             }
         }
     }
 
-    private async readFile(fileEntry: ResultsFile, entry: Entry): Promise<ArrayBuffer> {
-        if (!entry.getData) {
-            throw new Error('Entry does not have data')
-        }
-
+    private async readFile(fileEntry: ResultsFile, entry: ZipFileEntry): Promise<ArrayBuffer> {
         logger.info(`Reading file ${entry.filename}`)
 
         const encryptedData = await entry.getData(new BlobWriter())

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@zip.js/zip.js": "^2.7.72",
+                "@zip.js/zip.js": "^2.8.23",
                 "debug": "^4.4.1"
             },
             "devDependencies": {
@@ -1414,12 +1414,14 @@
             }
         },
         "node_modules/@zip.js/zip.js": {
-            "version": "2.7.72",
+            "version": "2.8.23",
+            "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.23.tgz",
+            "integrity": "sha512-RB+RLnxPJFPrGvQ9rgO+4JOcsob6lD32OcF0QE0yg24oeW9q8KnTTNlugcDaIveEcCbclobJcZP+fLQ++sH0bw==",
             "license": "BSD-3-Clause",
             "engines": {
                 "bun": ">=0.7.0",
                 "deno": ">=1.0.0",
-                "node": ">=16.5.0"
+                "node": ">=18.0.0"
             }
         },
         "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "vitest": "*"
     },
     "dependencies": {
-        "@zip.js/zip.js": "^2.7.72",
+        "@zip.js/zip.js": "^2.8.23",
         "debug": "^4.4.1"
     }
 }


### PR DESCRIPTION
Users of this library such as TOA are depending on [recent versions of zip.js](https://github.com/safeinsights/trusted-output-app/blob/d9c7dfd247c40dc575cb0ef740f322b9231b6d2d/package-lock.json#L2443) which results in type errors here. This PR updates the dependency in this repo and fixes the issues for downstream.