### PR TITLE
add listFiles and extractFile methods to ResultsReader

### DIFF
--- a/job-results/index.ts
+++ b/job-results/index.ts
@@ -1,2 +1,3 @@
 export * from './reader'
 export * from './writer'
+export type { FileInfo } from './types'

--- a/job-results/reader-writer.test.ts
+++ b/job-results/reader-writer.test.ts
@@ -4,6 +4,11 @@ import { fingerprintKeyData, pemToArrayBuffer } from '../util'
 import { ResultsWriter } from './writer'
 import { ResultsReader } from './reader'
 
+const toArrayBuffer = (str: string): ArrayBuffer => {
+    const buf = Buffer.from(str, 'utf-8')
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)
+}
+
 describe('Encryption Library Tests', async () => {
     it('can create a results file and read it', async () => {
         const publicKey = pemToArrayBuffer(readPublicKey())
@@ -38,5 +43,75 @@ describe('Encryption Library Tests', async () => {
         expect(entries[0].path).toEqual('test.data')
 
         expect(new TextDecoder().decode(entries[0].contents)).toEqual('hello world!')
+    })
+})
+
+describe('listFiles and extractFile', async () => {
+    const publicKey = pemToArrayBuffer(readPublicKey())
+    const fingerprint = await fingerprintKeyData(publicKey)
+    const privateKey = pemToArrayBuffer(readPrivateKey())
+
+    const testFiles = [
+        { name: 'alpha.txt', content: 'Alpha content here' },
+        { name: 'beta.csv', content: 'col1,col2\nval1,val2' },
+        { name: 'gamma.json', content: '{"key":"value"}' },
+    ]
+
+    async function buildZip() {
+        const writer = new ResultsWriter([{ publicKey, fingerprint }])
+        for (const f of testFiles) {
+            await writer.addFile(f.name, toArrayBuffer(f.content))
+        }
+        return writer.generate()
+    }
+
+    it('listFiles returns correct names and sizes', async () => {
+        const zip = await buildZip()
+        const reader = new ResultsReader(zip, privateKey, fingerprint)
+
+        const files = await reader.listFiles()
+
+        expect(files).toHaveLength(3)
+        for (const f of testFiles) {
+            const info = files.find((fi) => fi.path === f.name)
+            expect(info).toBeDefined()
+            expect(info!.bytes).toBe(Buffer.byteLength(f.content, 'utf-8'))
+        }
+    })
+
+    it('extractFile decrypts a single file correctly', async () => {
+        const zip = await buildZip()
+        const reader = new ResultsReader(zip, privateKey, fingerprint)
+
+        const entry = await reader.extractFile('beta.csv')
+
+        expect(entry.path).toBe('beta.csv')
+        expect(new TextDecoder().decode(entry.contents)).toBe('col1,col2\nval1,val2')
+    })
+
+    it('extractFile throws for non-existent file', async () => {
+        const zip = await buildZip()
+        const reader = new ResultsReader(zip, privateKey, fingerprint)
+
+        await expect(reader.extractFile('nope.txt')).rejects.toThrow('File not found in manifest: nope.txt')
+    })
+
+    it('listFiles then extractFile works together', async () => {
+        const zip = await buildZip()
+        const reader = new ResultsReader(zip, privateKey, fingerprint)
+
+        const files = await reader.listFiles()
+        expect(files).toHaveLength(3)
+
+        const entry = await reader.extractFile('gamma.json')
+        expect(new TextDecoder().decode(entry.contents)).toBe('{"key":"value"}')
+    })
+
+    it('extractFile works without prior listFiles call', async () => {
+        const zip = await buildZip()
+        const reader = new ResultsReader(zip, privateKey, fingerprint)
+
+        const entry = await reader.extractFile('alpha.txt')
+        expect(new TextDecoder().decode(entry.contents)).toBe('Alpha content here')
     })
 })

--- a/job-results/reader.ts
+++ b/job-results/reader.ts
@@ -1,6 +1,6 @@
 import { BlobReader, BlobWriter, TextWriter, ZipReader } from '@zip.js/zip.js'
 import type { FileEntry as ZipFileEntry } from '@zip.js/zip.js'
-import type { ResultsFile, ResultsManifest, FileEntry } from './types'
+import type { ResultsFile, ResultsManifest, FileEntry, FileInfo } from './types'
 import { privateKeyFromBuffer } from '../util'
 import logger from '../lib/logger'
 
@@ -12,6 +12,7 @@ export class ResultsReader {
     private zipReader: ZipReader<Blob>
     private fingerprint: string
     private privateKey: ArrayBuffer
+    private decoded = false
 
     constructor(zipBlob: Blob, privateKey: ArrayBuffer, fingerprint: string) {
         this.zipReader = new ZipReader(new BlobReader(zipBlob))
@@ -37,6 +38,8 @@ export class ResultsReader {
     }
 
     async decode() {
+        if (this.decoded) return
+
         logger.info(`Decoding entries`)
 
         const entries = await this.zipReader.getEntries()
@@ -51,7 +54,31 @@ export class ResultsReader {
             throw new Error('Manifest not found in zip archive.')
         }
 
+        this.decoded = true
         logger.info(`Finished decoding entries`)
+    }
+
+    async listFiles(): Promise<FileInfo[]> {
+        await this.decode()
+        return Object.values(this.manifest.files).map(({ path, bytes }) => ({ path, bytes }))
+    }
+
+    async extractFile(filePath: string): Promise<FileEntry> {
+        await this.decode()
+
+        const file = this.manifest.files[filePath]
+        if (!file) {
+            throw new Error(`File not found in manifest: ${filePath}`)
+        }
+
+        const entries = await this.zipReader.getEntries()
+        const entry = entries.find((e) => !e.directory && e.filename === filePath)
+        if (!entry || entry.directory) {
+            throw new Error(`File not found in zip archive: ${filePath}`)
+        }
+
+        const contents = await this.readFile(file, entry)
+        return { path: filePath, contents }
     }
 
     async *entries(): AsyncGenerator<ResultsFile & { contents: ArrayBuffer }, void, void> {

--- a/job-results/types.ts
+++ b/job-results/types.ts
@@ -28,3 +28,8 @@ export type FileEntry = {
     path: string
     contents: ArrayBuffer
 }
+
+export type FileInfo = {
+    path: string
+    bytes: number // original (pre-encryption) file size
+}


### PR DESCRIPTION
Allow consumers to inspect zip contents without decrypting (`listFiles`) and selectively decrypt a single file by name (`extractFile`)