### PR TITLE
Fix vite and postcss security CVEs (SIINFOSEC-224/240/243/389)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
                 "@eslint/js": "*",
                 "@types/debug": "^4.1.12",
                 "@types/node": "^24.2.1",
-                "@vitest/coverage-v8": "^4.1.2",
+                "@vitest/coverage-v8": "^4.1.5",
                 "eslint": "*",
                 "happy-dom": "*",
                 "prettier": "*",
                 "tsx": "^4.20.4",
                 "typescript-eslint": "^8.49.0",
-                "vitest": "*"
+                "vitest": "^4.1.5"
             }
         },
         "node_modules/@babel/helper-string-parser": {
@@ -749,9 +749,9 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-            "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -768,9 +768,9 @@
             }
         },
         "node_modules/@oxc-project/types": {
-            "version": "0.122.0",
-            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+            "version": "0.127.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+            "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -778,9 +778,9 @@
             }
         },
         "node_modules/@rolldown/binding-android-arm64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
             "cpu": [
                 "arm64"
             ],
@@ -795,9 +795,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-arm64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
             "cpu": [
                 "arm64"
             ],
@@ -812,9 +812,9 @@
             }
         },
         "node_modules/@rolldown/binding-darwin-x64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
             "cpu": [
                 "x64"
             ],
@@ -829,9 +829,9 @@
             }
         },
         "node_modules/@rolldown/binding-freebsd-x64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
             "cpu": [
                 "x64"
             ],
@@ -846,9 +846,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+            "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
             "cpu": [
                 "arm"
             ],
@@ -863,9 +863,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-gnu": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
             "cpu": [
                 "arm64"
             ],
@@ -880,9 +880,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-arm64-musl": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
             "cpu": [
                 "arm64"
             ],
@@ -897,9 +897,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
             "cpu": [
                 "ppc64"
             ],
@@ -914,9 +914,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-s390x-gnu": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
             "cpu": [
                 "s390x"
             ],
@@ -931,9 +931,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-gnu": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-            "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+            "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
             "cpu": [
                 "x64"
             ],
@@ -948,9 +948,9 @@
             }
         },
         "node_modules/@rolldown/binding-linux-x64-musl": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
             "cpu": [
                 "x64"
             ],
@@ -965,9 +965,9 @@
             }
         },
         "node_modules/@rolldown/binding-openharmony-arm64": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+            "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
             "cpu": [
                 "arm64"
             ],
@@ -982,9 +982,9 @@
             }
         },
         "node_modules/@rolldown/binding-wasm32-wasi": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+            "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
             "cpu": [
                 "wasm32"
             ],
@@ -992,16 +992,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^1.1.1"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
             "cpu": [
                 "arm64"
             ],
@@ -1016,9 +1018,9 @@
             }
         },
         "node_modules/@rolldown/binding-win32-x64-msvc": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+            "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
             "cpu": [
                 "x64"
             ],
@@ -1033,9 +1035,9 @@
             }
         },
         "node_modules/@rolldown/pluginutils": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+            "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
             "dev": true,
             "license": "MIT"
         },
@@ -1360,14 +1362,15 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
-            "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+            "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.1.2",
+                "@vitest/utils": "4.1.5",
                 "ast-v8-to-istanbul": "^1.0.0",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
@@ -1381,8 +1384,8 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "4.1.2",
-                "vitest": "4.1.2"
+                "@vitest/browser": "4.1.5",
+                "vitest": "4.1.5"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -1391,16 +1394,16 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-            "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.1.2",
-                "@vitest/utils": "4.1.2",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "chai": "^6.2.2",
                 "tinyrainbow": "^3.1.0"
             },
@@ -1409,9 +1412,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-            "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1422,13 +1425,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-            "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.1.2",
+                "@vitest/utils": "4.1.5",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1436,14 +1439,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-            "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.2",
-                "@vitest/utils": "4.1.2",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1452,9 +1455,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-            "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1462,13 +1465,13 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-            "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.1.2",
+                "@vitest/pretty-format": "4.1.5",
                 "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.1.0"
             },
@@ -1649,9 +1652,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -2596,9 +2599,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.8",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-            "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+            "version": "8.5.12",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+            "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
             "dev": true,
             "funding": [
                 {
@@ -2665,14 +2668,14 @@
             }
         },
         "node_modules/rolldown": {
-            "version": "1.0.0-rc.12",
-            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+            "version": "1.0.0-rc.17",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+            "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@oxc-project/types": "=0.122.0",
-                "@rolldown/pluginutils": "1.0.0-rc.12"
+                "@oxc-project/types": "=0.127.0",
+                "@rolldown/pluginutils": "1.0.0-rc.17"
             },
             "bin": {
                 "rolldown": "bin/cli.mjs"
@@ -2681,21 +2684,21 @@
                 "node": "^20.19.0 || >=22.12.0"
             },
             "optionalDependencies": {
-                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+                "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
             }
         },
         "node_modules/semver": {
@@ -2732,6 +2735,8 @@
         },
         "node_modules/siginfo": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true,
             "license": "ISC"
         },
@@ -2747,13 +2752,15 @@
         },
         "node_modules/stackback": {
             "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -2772,13 +2779,15 @@
         },
         "node_modules/tinybench": {
             "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
-            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+            "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2786,12 +2795,14 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -2932,19 +2943,20 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-            "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@vitest/expect": "4.1.2",
-                "@vitest/mocker": "4.1.2",
-                "@vitest/pretty-format": "4.1.2",
-                "@vitest/runner": "4.1.2",
-                "@vitest/snapshot": "4.1.2",
-                "@vitest/spy": "4.1.2",
-                "@vitest/utils": "4.1.2",
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
                 "es-module-lexer": "^2.0.0",
                 "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
@@ -2972,10 +2984,12 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.1.2",
-                "@vitest/browser-preview": "4.1.2",
-                "@vitest/browser-webdriverio": "4.1.2",
-                "@vitest/ui": "4.1.2",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
                 "happy-dom": "*",
                 "jsdom": "*",
                 "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2999,6 +3013,12 @@
                 "@vitest/browser-webdriverio": {
                     "optional": true
                 },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
                 "@vitest/ui": {
                     "optional": true
                 },
@@ -3014,9 +3034,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
             "cpu": [
                 "ppc64"
             ],
@@ -3031,9 +3051,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/android-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
             "cpu": [
                 "arm"
             ],
@@ -3048,9 +3068,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
             "cpu": [
                 "arm64"
             ],
@@ -3065,9 +3085,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/android-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
             "cpu": [
                 "x64"
             ],
@@ -3082,9 +3102,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3099,9 +3119,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
             "cpu": [
                 "x64"
             ],
@@ -3116,9 +3136,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -3133,9 +3153,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
             "cpu": [
                 "x64"
             ],
@@ -3150,9 +3170,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
             "cpu": [
                 "arm"
             ],
@@ -3167,9 +3187,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
             "cpu": [
                 "arm64"
             ],
@@ -3184,9 +3204,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
             "cpu": [
                 "ia32"
             ],
@@ -3201,9 +3221,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
             "cpu": [
                 "loong64"
             ],
@@ -3218,9 +3238,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
             "cpu": [
                 "mips64el"
             ],
@@ -3235,9 +3255,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
             "cpu": [
                 "ppc64"
             ],
@@ -3252,9 +3272,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -3269,9 +3289,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
             "cpu": [
                 "s390x"
             ],
@@ -3286,9 +3306,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
             "cpu": [
                 "x64"
             ],
@@ -3303,9 +3323,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
             "cpu": [
                 "arm64"
             ],
@@ -3320,9 +3340,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
             "cpu": [
                 "x64"
             ],
@@ -3337,9 +3357,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
             "cpu": [
                 "arm64"
             ],
@@ -3354,9 +3374,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
             "cpu": [
                 "x64"
             ],
@@ -3371,9 +3391,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
             "cpu": [
                 "arm64"
             ],
@@ -3388,9 +3408,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
             "cpu": [
                 "x64"
             ],
@@ -3405,9 +3425,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
             "cpu": [
                 "arm64"
             ],
@@ -3422,9 +3442,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
             "cpu": [
                 "ia32"
             ],
@@ -3439,9 +3459,9 @@
             }
         },
         "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
             "cpu": [
                 "x64"
             ],
@@ -3456,13 +3476,13 @@
             }
         },
         "node_modules/vitest/node_modules/@vitest/mocker": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-            "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.1.2",
+                "@vitest/spy": "4.1.5",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -3483,18 +3503,18 @@
             }
         },
         "node_modules/vitest/node_modules/vite": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-            "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+            "version": "8.0.10",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+            "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
-                "postcss": "^8.5.8",
-                "rolldown": "1.0.0-rc.12",
-                "tinyglobby": "^0.2.15"
+                "postcss": "^8.5.10",
+                "rolldown": "1.0.0-rc.17",
+                "tinyglobby": "^0.2.16"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -3511,7 +3531,7 @@
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
                 "@vitejs/devtools": "^0.1.0",
-                "esbuild": "^0.27.0",
+                "esbuild": "^0.27.0 || ^0.28.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
                 "sass": "^1.70.0",
@@ -3585,6 +3605,8 @@
         },
         "node_modules/why-is-node-running": {
             "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
         "@eslint/js": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^24.2.1",
-        "@vitest/coverage-v8": "^4.1.2",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "*",
         "happy-dom": "*",
         "prettier": "*",
         "tsx": "^4.20.4",
         "typescript-eslint": "^8.49.0",
-        "vitest": "*"
+        "vitest": "^4.1.5"
     },
     "dependencies": {
         "@zip.js/zip.js": "^2.8.23",


### PR DESCRIPTION
## Summary
- Upgrades `vitest` 4.1.2 → 4.1.5 and `@vitest/coverage-v8` 4.1.2 → 4.1.5, which transitively pulls in `vite` 8.0.10 and `postcss` 8.5.12.
- Resolves all four open SIINFOSEC tickets for this repository.
- `npm audit` now reports **0 vulnerabilities** (was 5: 4 moderate, 1 high).

## CVEs addressed
| Ticket | CVE | Severity | Component |
| --- | --- | --- | --- |
| [SIINFOSEC-224](https://openstax.atlassian.net/browse/SIINFOSEC-224) | CVE-2026-39363 | HIGH | vite — arbitrary file read via dev server WebSocket |
| [SIINFOSEC-240](https://openstax.atlassian.net/browse/SIINFOSEC-240) | CVE-2026-39364 | HIGH | vite — `server.fs.deny` bypassed with queries |
| [SIINFOSEC-243](https://openstax.atlassian.net/browse/SIINFOSEC-243) | CVE-2026-39365 | MEDIUM | vite — path traversal in optimized deps `.map` handling |
| [SIINFOSEC-389](https://openstax.atlassian.net/browse/SIINFOSEC-389) | CVE-2026-41305 | MEDIUM | postcss — XSS via unescaped `</style>` |

## Test plan
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` — 13 tests pass

[SIINFOSEC-224]: https://openstax.atlassian.net/browse/SIINFOSEC-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIINFOSEC-240]: https://openstax.atlassian.net/browse/SIINFOSEC-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIINFOSEC-243]: https://openstax.atlassian.net/browse/SIINFOSEC-243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIINFOSEC-389]: https://openstax.atlassian.net/browse/SIINFOSEC-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ